### PR TITLE
precompile `__init__`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CPUSummary"
 uuid = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
 authors = ["chriselrod <elrodc@gmail.com> and contributors"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 CpuId = "adafc99b-e345-5852-983c-f28acb93d879"

--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,14 @@ version = "0.2.2"
 [deps]
 CpuId = "adafc99b-e345-5852-983c-f28acb93d879"
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 
 [compat]
 CpuId = "0.3"
 IfElse = "0.1"
 Static = "0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8"
+PrecompileTools = "1.1"
 julia = "1.6"
 
 [extras]

--- a/src/CPUSummary.jl
+++ b/src/CPUSummary.jl
@@ -66,6 +66,7 @@ function __init__()
     @eval sys_threads() = static($syst)
   end
   _extra_init()
+  return nothing
 end
 
 
@@ -92,6 +93,11 @@ function num_cache_levels()
     ),
     StaticInt{4}(),
   )
+end
+
+# explicit precompilation only on Julia v1.9 and newer
+if VERSION >= v"1.9"
+  include("precompile.jl")
 end
 
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,10 @@
+using PrecompileTools: @compile_workload
+
+@compile_workload begin
+  __init__()
+  # `_extra_init()` is called by `__init__()`
+  # However, it does not seem to be recognized correctly since we can
+  # further reduce the time of `using CPUSummary` significantly by
+  # precompiling it here in addition ot `__init__()`.
+  _extra_init()
+end

--- a/src/x86.jl
+++ b/src/x86.jl
@@ -53,6 +53,7 @@ function _extra_init()
   cs !== PrecompiledCacheSize && _eval_cache_size(cs)
   ci = CpuId.cacheinclusive()
   ci !== PrecompiledCacheInclusive && _eval_cache_inclusive(ci)
+  return nothing
 end
 
 


### PR DESCRIPTION
I noticed that this package has a non-negligible `using` time when looking at `@time_imports using Trixi`. I added some explicit precompile statements for Julia v1.9 and newer to reduce this.

Current `main` branch:
```
$ julia --project=. -e 'import Pkg; Pkg.resolve(); Pkg.precompile(); using InteractiveUtils; @time_imports using CPUSummary'
  No Changes to `~/.julia/dev/CPUSummary/Project.toml`
  No Changes to `~/.julia/dev/CPUSummary/Manifest.toml`
      0.1 ms  IfElse
     18.6 ms  Static
      0.8 ms  CpuId
    153.9 ms  CPUSummary 96.24% compilation time
```

This PR:
```
$ julia --project=. -e 'import Pkg; Pkg.resolve(); Pkg.precompile(); using InteractiveUtils; @time_imports using CPUSummary'
  No Changes to `~/.julia/dev/CPUSummary/Project.toml`
  No Changes to `~/.julia/dev/CPUSummary/Manifest.toml`
      0.1 ms  IfElse
     18.6 ms  Static
      0.7 ms  CpuId
      9.3 ms  Preferences
      0.2 ms  PrecompileTools
     14.3 ms  CPUSummary 62.64% compilation time
```

This is on an old notebook with Intel X86 CPU. The remaining compilation time seems to come from CpuId.jl, which is used in
https://github.com/JuliaSIMD/CPUSummary.jl/blob/93aef785f94fe8d9a3dde70f7d09e0fcc2215232/src/x86.jl#L49-L56
Commenting out the line `ci = CpuId.cacheinclusive()` removes the remaining compilation time.